### PR TITLE
Added file close to SXM.py

### DIFF
--- a/pySPM/SXM.py
+++ b/pySPM/SXM.py
@@ -45,6 +45,9 @@ class SXM:
                 'unit': 'm'
             })
 
+    def closefile(self):
+        self.f.close()
+
     def list_channels(self):
         print("Channels")
         print("========")


### PR DESCRIPTION
Added method to close sxm files to avoid file system conflicts during batch processing of SXM files. File system errors were generated when trying to open, process, and then move sxm files to new directories. This change allows the user to close the file after processing with pySPM, thereby avoiding the error.