### PR TITLE
scikit-image dependency >=0.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{ include = "pySPM" }]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 scikit-learn = "^1.2.2"
-scikit-image = "^0.21.0"
+scikit-image = ">=0.21.0"
 numpy = "^1.26.0"
 matplotlib = "^3.7.1"
 seaborn = "^0.13.0"


### PR DESCRIPTION
I'm working on adding Python 3.12 support to [TopoStats](https://github.com/AFM-SPM/TopoStats/) which depends on `pyspm` for loading files.

In the process of doing so under a Conda environment using Python 3.12 that `pyspm` had a dependency on `scikit-image = "^=0.21.0"` and that `scikit-image` then threw an error with regards to `libstdc++.so.6`. Support for Python 3.12 was added to `scikit-image-0.22.0` (see [thread](https://github.com/scikit-image/scikit-image/issues/7149#issuecomment-1739552345)) and I found that updating to `scikit-image-0.22.0` solved the `libstdc++.so.6` issue.

To help others avoid this problem I've checked that `pyspm` works with `scikit-image-0.22.0` and all tests have passed when loosening the dependency to `scikit-image = ">=0.21.0"` and using the latest version of `scikit-image-0.22.0`.

```bash
❱ pip show scikit-image | head -n 10
Name: scikit-image
Version: 0.22.0
Summary: Image processing in Python
Home-page: https://scikit-image.org
Author: 
Author-email: 
License: Files: *
Copyright: 2009-2022 the scikit-image team
License: BSD-3-Clause

❱ pytest
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.12.0, pytest-7.4.3, pluggy-1.3.0
Matplotlib: 3.8.2
Freetype: 2.6.1
rootdir: /home/neil/work/git/hub/ns-rse/pySPM
plugins: mpl-0.16.1, github-actions-annotate-failures-0.2.0, regtest-1.5.1, cov-4.1.0, lazy-fixture-0.6.3
collected 6 items                                                                                                                                                                  

tests/test_ITA.py ...                                                                                                                                                        [ 50%]
tests/test_PCA.py .                                                                                                                                                          [ 66%]
tests/test_elts.py .                                                                                                                                                         [ 83%]
tests/test_modules.py .                                                                                                                                                      [100%]

================================================================================= warnings summary =================================================================================
../../../../../miniconda3/envs/topo312/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /home/neil/miniconda3/envs/topo312/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================== 6 passed, 1 warning in 1.00s ===========================================================================
```