### PR TITLE
bug: handle UnboundLocalError in Bruker files

### DIFF
--- a/pySPM/Bruker.py
+++ b/pySPM/Bruker.py
@@ -158,6 +158,8 @@ class Bruker:
                     )
                 except KeyError:
                     continue
+                except UnboundLocalError:
+                    continue
             else:
                 _type = "Bruker AFM"
                 try:
@@ -165,6 +167,8 @@ class Bruker:
                         encoding
                     )
                 except KeyError:
+                    continue
+                except UnboundLocalError:
                     continue
             result = re.match(r'([^ ]+) \[([^]]*)] "([^"]*)"', layer_name).groups()
             if result[2] == channel:


### PR DESCRIPTION
Closes #56

Adds another `except` to capture `UnboundLocalError` that arise in some Bruker files which appear to be a mixture of
AFM/MFM.